### PR TITLE
Clean up the announcement date metabox

### DIFF
--- a/includes/wsu-content-type-announcement.php
+++ b/includes/wsu-content-type-announcement.php
@@ -144,9 +144,7 @@ class WSU_Content_Type_Announcement {
 		$date_input = '';
 		$date_input_count = 1;
 		$archive_dates = array( 'daily', 'monthly', 'yearly' );
-		?>
-		<p>This announcement will appear on the following announcement archive pages:</p>
-		<?php
+
 		foreach ( $results as $result ) {
 			$date = str_replace( '_announcement_date_', '', $result->meta_key );
 
@@ -175,9 +173,9 @@ class WSU_Content_Type_Announcement {
 			$date_input_count++;
 		}
 		?>
-		<label for="announcement-form-date">This announcement will appear on the following date(s):</label><br /><br />
+		<label for="announcement-form-date">This announcement is assigned to the following date(s):</label><br /><br />
 		<?php echo $date_input;	?>
-		<p>This announcement will appear on the following announcement archive pages:</p>
+		<p>It will appear on the following announcement archive pages:</p>
 		<ul>
 			<li>Yearly: <?php echo implode( ', ', $archive_dates['yearly'] ); ?></li>
 			<li>Monthly: <?php echo implode( ', ', $archive_dates['monthly'] ); ?></li>


### PR DESCRIPTION
Now that we allow editing of announcement dates in the admin, things should be cleaned up a bit to be a little friendlier.
- [x] Put date inputs above archive links
- [x] Only list Daily, Monthly, and Yearly rows once. Multiple dates should be comma separated.
- [ ] For extra credit, have a box to add a date so that an announcement could appear more than 3 times.
